### PR TITLE
feat: Add celestial_tag function for generating names from catalog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # radio-galaxy-classifier
 
 [![Release](https://img.shields.io/github/v/release/mirsazzathossain/radio-galaxy-classifier)](https://img.shields.io/github/v/release/mirsazzathossain/radio-galaxy-classifier)
-[![Build status](https://img.shields.io/github/actions/workflow/status/mirsazzathossain/radio-galaxy-classifier/ci.yml?branch=main)](https://github.com/mirsazzathossain/radio-galaxy-classifier/actions/workflows/main.yml?query=branch%3Amain)
+[![Build status](https://img.shields.io/github/actions/workflow/status/mirsazzathossain/radio-galaxy-classifier/ci.yml?branch=main)](https://github.com/mirsazzathossain/radio-galaxy-classifier/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/mirsazzathossain/radio-galaxy-classifier/branch/main/graph/badge.svg)](https://codecov.io/gh/mirsazzathossain/radio-galaxy-classifier)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/mirsazzathossain/radio-galaxy-classifier)](https://img.shields.io/github/commit-activity/m/mirsazzathossain/radio-galaxy-classifier)
 [![License](https://img.shields.io/github/license/mirsazzathossain/radio-galaxy-classifier?label=license)](https://img.shields.io/github/license/mirsazzathossain/radio-galaxy-classifier?label=license)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # radio-galaxy-classifier
 
 [![Release](https://img.shields.io/github/v/release/mirsazzathossain/radio-galaxy-classifier)](https://img.shields.io/github/v/release/mirsazzathossain/radio-galaxy-classifier)
-[![Build status](https://img.shields.io/github/actions/workflow/status/mirsazzathossain/radio-galaxy-classifier/main.yml?branch=main)](https://github.com/mirsazzathossain/radio-galaxy-classifier/actions/workflows/main.yml?query=branch%3Amain)
+[![Build status](https://img.shields.io/github/actions/workflow/status/mirsazzathossain/radio-galaxy-classifier/ci.yml?branch=main)](https://github.com/mirsazzathossain/radio-galaxy-classifier/actions/workflows/ci.yml?query=branch%3Amain)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/mirsazzathossain/radio-galaxy-classifier)](https://img.shields.io/github/commit-activity/m/mirsazzathossain/radio-galaxy-classifier)
 [![License](https://img.shields.io/github/license/mirsazzathossain/radio-galaxy-classifier)](https://img.shields.io/github/license/mirsazzathossain/radio-galaxy-classifier)
 

--- a/rgc/utils/data.py
+++ b/rgc/utils/data.py
@@ -76,26 +76,33 @@ def celestial_capture(survey: str, ra: float, dec: float, filename: str) -> None
     image.writeto(filename, overwrite=True)
 
 
-def celestial_tag(entry: pd.DataFrame) -> str:
+def celestial_tag(entry: pd.Series) -> str:
     """
-    Generate name tag for a celestial object.
+    Generate a name tag for a celestial object based on its coordinates.
 
-    :param entry: A pandas DataFrame entry of the catalog.
-    :type entry: pd.DataFrame
+    :param entry: A pandas Series entry of the catalog.
+    :type entry: pd.Series
 
     :return: A string containing the name tag.
     :rtype: str
     """
-    if {"RAJ2000", "DEJ2000"}.issubset(entry.keys()):
-        return f"{entry['RAJ2000']}{'+' if entry['DEJ2000'] > 0 else ''}{entry['DEJ2000']}"
-    elif {"RA", "DEC"}.issubset(entry.keys()):
-        return f"{entry['RA']}{'+' if entry['DEC'] > 0 else ''}{entry['DEC']}"
-    elif "filename" in entry:
-        return entry["filename"]
-    elif "FCG" in entry:
-        return entry["FCG"]
+
+    def format_dec(dec: str) -> str:
+        sign = "+" if float(dec.replace(" ", "")) > 0 else ""
+        return f"{sign}{dec}"
+
+    if {"RAJ2000", "DEJ2000"}.issubset(entry.index):
+        ra, dec = entry["RAJ2000"], entry["DEJ2000"]
+    elif {"RA", "DEC"}.issubset(entry.index):
+        ra, dec = entry["RA"], entry["DEC"]
+    elif "filename" in entry.index:
+        return f"{entry['filename']}"
+    elif "FCG" in entry.index:
+        return f"{entry['FCG']}"
     else:
         raise _NoValidCelestialCoordinatesError()
+
+    return f"{ra}{format_dec(dec)}"
 
 
 class _NoValidCelestialCoordinatesError(Exception):

--- a/tests/test_celestial_tag.py
+++ b/tests/test_celestial_tag.py
@@ -1,0 +1,54 @@
+import unittest
+
+import pandas as pd
+import pytest
+
+from rgc.utils.data import _NoValidCelestialCoordinatesError, celestial_tag
+
+
+class TestCelestialTag:
+    def test_celestial_tag_ra_dec_format(self):
+        # Test with RA and DEC in degrees, minutes, seconds format
+        data = pd.DataFrame([{"RA": "00 01 15.11", "DEC": "-08 26 46.2"}])
+        tag = celestial_tag(data.iloc[0])
+        assert tag == "00 01 15.11-08 26 46.2"
+
+    def test_celestial_tag_ra_dec_format_negative_dec(self):
+        # Test with RA and DEC in degrees, minutes, seconds format with negative DEC
+        data = pd.DataFrame([{"RA": "00 01 15.11", "DEC": "-08 26 46.2"}])
+        tag = celestial_tag(data.iloc[0])
+        assert tag == "00 01 15.11-08 26 46.2"
+
+    def test_celestial_tag_ra_dec_format_without_sign(self):
+        # Test with RA and DEC in degrees, minutes, seconds format where DEC is positive but no explicit sign
+        data = pd.DataFrame([{"RA": "00 01 15.11", "DEC": "08 26 46.2"}])
+        tag = celestial_tag(data.iloc[0])
+        assert tag == "00 01 15.11+08 26 46.2"
+
+    def test_celestial_tag_ra_j2000_format(self):
+        # Test with RAJ2000 and DEJ2000 format
+        data = pd.DataFrame([{"RAJ2000": "00 01 15.11", "DEJ2000": "-08 26 46.2"}])
+        tag = celestial_tag(data.iloc[0])
+        assert tag == "00 01 15.11-08 26 46.2"
+
+    def test_celestial_tag_filename_format(self):
+        # Test with filename format
+        data = pd.DataFrame([{"filename": "object123.fits"}])
+        tag = celestial_tag(data.iloc[0])
+        assert tag == "object123.fits"
+
+    def test_celestial_tag_fcg_format(self):
+        # Test with FCG format
+        data = pd.DataFrame([{"FCG": "object456"}])
+        tag = celestial_tag(data.iloc[0])
+        assert tag == "object456"
+
+    def test_celestial_tag_missing_coordinates(self):
+        # Test with missing coordinates
+        data = pd.DataFrame([{}])
+        with pytest.raises(_NoValidCelestialCoordinatesError):
+            celestial_tag(data.iloc[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Implemented `celestial_tag` function to generate names for astronomical objects based on catalog data (Issue #4).
- Handles different catalog formats including RA/Dec coordinates and filenames.
- Added custom exception `_NoValidCelestialCoordinatesError` for handling missing or invalid coordinates.