### PR TITLE
feat(utils): add functionality to convert FITS images to PNG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,28 @@
 
 ### Chore
 
-* chore: Update build status badge URL in README.md and docs/index.md ([`ce88c2e`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/ce88c2e169ec227296c23593a61fcb0862b1c8af))
+- chore: Update build status badge URL in README.md and docs/index.md ([`ce88c2e`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/ce88c2e169ec227296c23593a61fcb0862b1c8af))
 
 ### Feature
 
-* feat: Add celestial_tag function for generating names from catalog entries
+- feat: Add celestial_tag function for generating names from catalog entries
 
-- Modify the celestial_tag function to accept a pandas Series entry instead of a DataFrame entry.
-- Update the function to generate a name tag for a celestial object based on its coordinates.
-- Refactor the function to handle different coordinate formats and handle missing coordinates.
-- Add unit tests for the celestial_tag function to ensure its correctness.
+* Modify the celestial_tag function to accept a pandas Series entry instead of a DataFrame entry.
+* Update the function to generate a name tag for a celestial object based on its coordinates.
+* Refactor the function to handle different coordinate formats and handle missing coordinates.
+* Add unit tests for the celestial_tag function to ensure its correctness.
 
 Fixes #123 ([`d4b7dcd`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/d4b7dcde2cb39e703056ef9c257a807095858f9b))
 
-* feat: Add celestial_tag function for generating names from catalog entries
+- feat: Add celestial_tag function for generating names from catalog entries
 
-- Implemented `celestial_tag` function to generate names for astronomical objects based on catalog data (Issue #4).
-- Handles different catalog formats including RA/Dec coordinates and filenames.
-- Added custom exception `_NoValidCelestialCoordinatesError` for handling missing or invalid coordinates. ([`3131518`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/313151816534ae77e4fb1dec159542e13787e24d))
+* Implemented `celestial_tag` function to generate names for astronomical objects based on catalog data (Issue #4).
+* Handles different catalog formats including RA/Dec coordinates and filenames.
+* Added custom exception `_NoValidCelestialCoordinatesError` for handling missing or invalid coordinates. ([`3131518`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/313151816534ae77e4fb1dec159542e13787e24d))
 
 ### Unknown
 
-* Merge pull request #12 from mirsazzathossain/dev
+- Merge pull request #12 from mirsazzathossain/dev
 
 feat: Add celestial_tag function for generating names from catalog entries ([`3aadc94`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/3aadc94d5a330680d97ab0e9e62eabe30b44e05d))
 
@@ -33,55 +33,55 @@ feat: Add celestial_tag function for generating names from catalog entries ([`3a
 
 ### Build
 
-* build: vpdate python version ([`228576b`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/228576b19d9ec3b61cbcebe4c365656329dd362b))
+- build: vpdate python version ([`228576b`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/228576b19d9ec3b61cbcebe4c365656329dd362b))
 
 ### Chore
 
-* chore(release): update version to 0.3.0 ([`276517a`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/276517aa3ff869187dd26a94af107024f1e23da5))
+- chore(release): update version to 0.3.0 ([`276517a`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/276517aa3ff869187dd26a94af107024f1e23da5))
 
-* chore: Update pandas-stubs dependency to version 3.14.0 ([`4f71c30`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/4f71c302ab8bd3f63514acc54c7c4d7fd7395b1c))
+- chore: Update pandas-stubs dependency to version 3.14.0 ([`4f71c30`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/4f71c302ab8bd3f63514acc54c7c4d7fd7395b1c))
 
-* chore: Update pandas dependency to version 2.0.3 ([`cf2c81e`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/cf2c81ebe5536eafedd05c58a0ef5f035e2b91d4))
+- chore: Update pandas dependency to version 2.0.3 ([`cf2c81e`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/cf2c81ebe5536eafedd05c58a0ef5f035e2b91d4))
 
-* chore: Update pandas dependency to pandas-stubs 2.0.2.230605 ([`8534477`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/85344774b9f2ce7e7a36bb63525d0cfa78f82074))
+- chore: Update pandas dependency to pandas-stubs 2.0.2.230605 ([`8534477`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/85344774b9f2ce7e7a36bb63525d0cfa78f82074))
 
-* chore: remove mypy configuration file and update pyproject.toml ([`a11bfaf`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/a11bfaf680f751431069251c109f856ebcabe778))
+- chore: remove mypy configuration file and update pyproject.toml ([`a11bfaf`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/a11bfaf680f751431069251c109f856ebcabe778))
 
 ### Ci
 
-* ci: Update python-version options in ci.yml ([`838f27c`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/838f27cf85b9aef31afbf3f485e9cc5289b0d994))
+- ci: Update python-version options in ci.yml ([`838f27c`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/838f27cf85b9aef31afbf3f485e9cc5289b0d994))
 
-* ci: update default Python version to 3.11 in setup-python-env action.yml ([`4ee87b6`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/4ee87b65b5e8d650ea2d4b745c2602549e5c9578))
+- ci: update default Python version to 3.11 in setup-python-env action.yml ([`4ee87b6`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/4ee87b65b5e8d650ea2d4b745c2602549e5c9578))
 
 ### Documentation
 
-* docs: refactor module import in docs ([`42f3b65`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/42f3b65463a09147157363a626c25d0ca6466197))
+- docs: refactor module import in docs ([`42f3b65`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/42f3b65463a09147157363a626c25d0ca6466197))
 
-* docs: update CHANGELOG.md ([`217fb5a`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/217fb5acf400880bf1a15a9d2ca7cb336fcd0ef5))
+- docs: update CHANGELOG.md ([`217fb5a`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/217fb5acf400880bf1a15a9d2ca7cb336fcd0ef5))
 
 ### Feature
 
-* feat: Add celestial_capture function for downloading images from SkyView
+- feat: Add celestial_capture function for downloading images from SkyView
 
-- Implemented `celestial_capture` function to retrieve and save celestial images from the NASA SkyView Virtual Observatory using given sky coordinates.
-- Supports various image surveys and includes error handling for invalid coordinates.
-- Saves FITS images with cleaned header comments and ensures directory creation.
+* Implemented `celestial_capture` function to retrieve and save celestial images from the NASA SkyView Virtual Observatory using given sky coordinates.
+* Supports various image surveys and includes error handling for invalid coordinates.
+* Saves FITS images with cleaned header comments and ensures directory creation.
 
 Closes #2 ([`39bccaa`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/39bccaaacb183aef9b4e049d5dc6c601cd816057))
 
 ### Refactor
 
-* refactor: update data.py to use type hinting for catalog_quest return value ([`77ea8c4`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/77ea8c46cfb8a88a5608b937faba42b4c9f111cf))
+- refactor: update data.py to use type hinting for catalog_quest return value ([`77ea8c4`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/77ea8c46cfb8a88a5608b937faba42b4c9f111cf))
 
 ### Test
 
-* test: Add unit test for celestial_capture function ([`c04cf53`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/c04cf5357e5e06dddb822b00597fa1165f84f9df))
+- test: Add unit test for celestial_capture function ([`c04cf53`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/c04cf5357e5e06dddb822b00597fa1165f84f9df))
 
-* test: Add mypy configuration file ([`c76f67f`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/c76f67f8769f7945f5bdea780957086312fb7fe7))
+- test: Add mypy configuration file ([`c76f67f`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/c76f67f8769f7945f5bdea780957086312fb7fe7))
 
 ### Unknown
 
-* Merge pull request #10 from mirsazzathossain/dev
+- Merge pull request #10 from mirsazzathossain/dev
 
 feat: Add celestial_capture function for downloading images from SkyView ([`1496ccf`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/1496ccf3060dd0a4ddf8229a186db222b5d16117))
 
@@ -89,29 +89,29 @@ feat: Add celestial_capture function for downloading images from SkyView ([`1496
 
 ### Chore
 
-* chore(release): update version to 0.2.0 ([`1573da9`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/1573da9e5b08326c5c62feb29403aa20382ac700))
+- chore(release): update version to 0.2.0 ([`1573da9`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/1573da9e5b08326c5c62feb29403aa20382ac700))
 
 ### Documentation
 
-* docs: update license in CHANGELOG.md ([`ebb7f39`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/ebb7f3950cd8cf340e8d78e3e6ee0d2135f10023))
+- docs: update license in CHANGELOG.md ([`ebb7f39`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/ebb7f3950cd8cf340e8d78e3e6ee0d2135f10023))
 
 ### Feature
 
-* feat: implement catalog fetching from Vizier
+- feat: implement catalog fetching from Vizier
 
-- Add `fetch_catalog` function to retrieve catalogs from Vizier service.
-- Implement `_UnsupportedServiceError` exception class for unsupported services.
-- Add tests for successful retrieval from Vizier and error handling for unsupported services.
+* Add `fetch_catalog` function to retrieve catalogs from Vizier service.
+* Implement `_UnsupportedServiceError` exception class for unsupported services.
+* Add tests for successful retrieval from Vizier and error handling for unsupported services.
 
 Closes #1 ([`19dbdad`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/19dbdada32defef0893a79be43408140dbe59438))
 
 ### Refactor
 
-* refactor: refactor `fetch_catalog` function to `catalog_quest` ([`b752bc2`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/b752bc2c453154381cbc2bbbccec1c1b853cbeac))
+- refactor: refactor `fetch_catalog` function to `catalog_quest` ([`b752bc2`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/b752bc2c453154381cbc2bbbccec1c1b853cbeac))
 
 ### Unknown
 
-* Merge pull request #8 from mirsazzathossain/dev
+- Merge pull request #8 from mirsazzathossain/dev
 
 feat: implement catalog fetching from Vizier #1 ([`1b0f41e`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/1b0f41ef0f2129d65c31710b7386fc9fb66d4b0a))
 
@@ -119,40 +119,40 @@ feat: implement catalog fetching from Vizier #1 ([`1b0f41e`](https://github.com/
 
 ### Chore
 
-* chore(release): update version to 0.1.0 ([`2fd7066`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/2fd7066b52c3d3d8248be042d420663c1024095b))
+- chore(release): update version to 0.1.0 ([`2fd7066`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/2fd7066b52c3d3d8248be042d420663c1024095b))
 
 ### Documentation
 
-* docs: update license ([`6f67257`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/6f67257a4527d5882f5c1acf3482358e1a535021))
+- docs: update license ([`6f67257`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/6f67257a4527d5882f5c1acf3482358e1a535021))
 
 ### Feature
 
-* feat: Add bug report and feature request issue templates ([`81dfb9b`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/81dfb9bbd2568a8ac9ff7235d7163cf17fe32993))
+- feat: Add bug report and feature request issue templates ([`81dfb9b`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/81dfb9bbd2568a8ac9ff7235d7163cf17fe32993))
 
 ### Refactor
 
-* refactor: remove unused foo.py and test_foo.py files ([`0267301`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/026730149289a50c4e06115cd498dae059456b78))
+- refactor: remove unused foo.py and test_foo.py files ([`0267301`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/026730149289a50c4e06115cd498dae059456b78))
 
-* refactor: update build status badge URL in README.md ([`d3cfb5d`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/d3cfb5df6fa9fe75dcbff53e5dca9b7f6b659079))
+- refactor: update build status badge URL in README.md ([`d3cfb5d`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/d3cfb5df6fa9fe75dcbff53e5dca9b7f6b659079))
 
-* refactor: refactor build process in cd.yml workflow ([`7525ac5`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/7525ac595dff64d35a9cdb9d9b48e98ccf57981e))
+- refactor: refactor build process in cd.yml workflow ([`7525ac5`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/7525ac595dff64d35a9cdb9d9b48e98ccf57981e))
 
 ## v0.0.0 (2024-09-14)
 
 ### Chore
 
-* chore(release): update version to 0.0.0 ([`3859775`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/38597753b89c0b6b78c7b456deb0cc7728039c3e))
+- chore(release): update version to 0.0.0 ([`3859775`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/38597753b89c0b6b78c7b456deb0cc7728039c3e))
 
-* chore: update pre-commit instructions in CONTRIBUTING.md
+- chore: update pre-commit instructions in CONTRIBUTING.md
 
-- Added instructions to run pre-commit checks manually
-- Updated mkdocs.yml to fix indentation
-- Removed unnecessary lines from LICENSE file
-- Updated devcontainer.json to remove empty features object
-- Added classifiers in pyproject.toml
-- Added dev dependencies in pyproject.toml
-- Updated semantic-release configuration in pyproject.toml ([`c739435`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/c7394356962540a91355550c5262552f4c2f1a77))
+* Added instructions to run pre-commit checks manually
+* Updated mkdocs.yml to fix indentation
+* Removed unnecessary lines from LICENSE file
+* Updated devcontainer.json to remove empty features object
+* Added classifiers in pyproject.toml
+* Added dev dependencies in pyproject.toml
+* Updated semantic-release configuration in pyproject.toml ([`c739435`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/c7394356962540a91355550c5262552f4c2f1a77))
 
 ### Unknown
 
-* Init commit ([`9f8a983`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/9f8a983680c581346f6c4822f8ee4b2123e86519))
+- Init commit ([`9f8a983`](https://github.com/mirsazzathossain/radio-galaxy-classifier/commit/9f8a983680c581346f6c4822f8ee4b2123e86519))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,11 @@ classifiers=[
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "astropy>=5.2.2",
     "astroquery>=0.4.7",
+    "numpy>=1.24.4",
     "pandas>=2.0.3",
+    "pillow>=10.4.0",
 ]
 
 [project.urls]

--- a/rgc/utils/data.py
+++ b/rgc/utils/data.py
@@ -8,12 +8,16 @@ manipulation.
 __author__ = "Mir Sazzat Hossain"
 
 
+import os
 from pathlib import Path
-from typing import cast
+from typing import Optional, cast
 
+import numpy as np
 import pandas as pd
+from astropy.io import fits
 from astroquery.skyview import SkyView
 from astroquery.vizier import Vizier
+from PIL import Image
 
 
 def catalog_quest(name: str, service: str = "Vizier") -> pd.DataFrame:
@@ -28,6 +32,8 @@ def catalog_quest(name: str, service: str = "Vizier") -> pd.DataFrame:
 
     :return: A pandas DataFrame containing the fetched catalog.
     :rtype: pd.DataFrame
+
+    :raises _UnsupportedServiceError: If an unsupported service is provided.
     """
     if service == "Vizier":
         Vizier.ROW_LIMIT = -1
@@ -54,10 +60,10 @@ def celestial_capture(survey: str, ra: float, dec: float, filename: str) -> None
     :type survey: str
 
     :param ra: The right ascension of the celestial object.
-    :type ra: float
+    :type ra: Skycoord
 
     :param dec: The declination of the celestial object.
-    :type dec: float
+    :type dec: Skycoord
 
     :param filename: The name of the file to save the image.
     :type filename: str
@@ -85,6 +91,8 @@ def celestial_tag(entry: pd.Series) -> str:
 
     :return: A string containing the name tag.
     :rtype: str
+
+    :raises _NoValidCelestialCoordinatesError: If no valid celestial coordinates are found in the entry.
     """
 
     def format_dec(dec: str) -> str:
@@ -112,3 +120,72 @@ class _NoValidCelestialCoordinatesError(Exception):
 
     def __init__(self) -> None:
         super().__init__("No valid celestial coordinates found in the entry to generate a tag.")
+
+
+class _FileNotFoundError(Exception):
+    """
+    An exception to be raised when the FITS file is not found.
+    """
+
+    def __init__(self, fits_file: str) -> None:
+        super().__init__(f"File {fits_file} not found.")
+
+
+def fits_to_png(fits_file: str, img_size: Optional[tuple[int, int]] = None) -> Image.Image:
+    """
+    Convert a FITS file to a PNG image.
+
+    :param fits_file: The path to the FITS file.
+    :type fits_file: str
+
+    :param img_size: The size of the output image.
+    :type img_size: Optional[tuple[int, int]]
+
+    :return: A PIL Image object containing the PNG image.
+    :rtype: Image.Image
+
+    :raises _FileNotFoundError: If the FITS file is not found.
+    """
+    try:
+        image = fits.getdata(fits_file)
+        header = fits.getheader(fits_file)
+    except FileNotFoundError as err:
+        raise _FileNotFoundError(fits_file) from err
+
+    if img_size is not None:
+        width, height = img_size
+    else:
+        width, height = header["NAXIS1"], header["NAXIS2"]
+
+    image = np.reshape(image, (height, width))
+    image[np.isnan(image)] = np.nanmin(image)
+
+    image = (image - np.nanmin(image)) / (np.nanmax(image) - np.nanmin(image)) * 255
+    image = image.astype(np.uint8)
+    image = Image.fromarray(image, mode="L")
+
+    return cast(Image.Image, image)
+
+
+def fits_to_png_bulk(fits_dir: str, png_dir: str, img_size: Optional[tuple[int, int]] = None) -> None:
+    """
+    Convert a directory of FITS files to PNG images.
+
+    :param fits_dir: The path to the directory containing the FITS files.
+    :type fits_dir: str
+
+    :param png_dir: The path to the directory to save the PNG images.
+    :type png_dir: str
+
+    :param img_size: The size of the output image.
+    :type img_size: Optional[tuple[int, int]]
+    """
+    fits_files = Path(fits_dir).rglob("*.fits")
+    for fits_file in fits_files:
+        image = fits_to_png(str(fits_file), img_size)
+
+        png_file = os.path.join(png_dir, fits_file.stem)
+        Path(png_file).parent.mkdir(parents=True, exist_ok=True)
+
+        if image is not None:
+            image.save(png_file)

--- a/tests/test_fits_to_png.py
+++ b/tests/test_fits_to_png.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from rgc.utils.data import _FileNotFoundError, fits_to_png
+
+
+class TestFitsToPng(unittest.TestCase):
+    @patch("rgc.utils.data.fits.getdata")
+    @patch("rgc.utils.data.fits.getheader")
+    @patch("rgc.utils.data.Image.fromarray")
+    def test_fits_to_png_success(self, mock_fromarray, mock_getheader, mock_getdata):
+        # Mock FITS data and header
+        mock_getdata.return_value = np.array([[1, 2], [3, 4]], dtype=np.float32)
+        mock_getheader.return_value = {"NAXIS1": 2, "NAXIS2": 2}
+
+        # Mock PIL Image object
+        mock_image = MagicMock()
+        mock_fromarray.return_value = mock_image
+
+        # Call function
+        result = fits_to_png("mock.fits")
+
+        # Extract the array passed to fromarray and check equality
+        args, kwargs = mock_fromarray.call_args
+        np.testing.assert_array_equal(args[0], np.array([[0, 85], [170, 255]], dtype=np.uint8))
+        self.assertEqual(kwargs.get("mode"), "L")
+        self.assertEqual(result, mock_image)
+
+    @patch("rgc.utils.data.fits.getdata")
+    @patch("rgc.utils.data.fits.getheader")
+    @patch("rgc.utils.data.Image.fromarray")
+    def test_fits_to_png_with_img_size(self, mock_fromarray, mock_getheader, mock_getdata):
+        # Mock FITS data and header
+        mock_getdata.return_value = np.array([1, 2, 3, 4], dtype=np.float32)
+        mock_getheader.return_value = {"NAXIS1": 2, "NAXIS2": 2}
+
+        # Mock PIL Image object
+        mock_image = MagicMock()
+        mock_fromarray.return_value = mock_image
+
+        # Call function with specific image size
+        _ = fits_to_png("mock.fits", img_size=(4, 1))
+
+        # Extract the array passed to fromarray and check equality
+        expected_image = np.array([0, 85, 170, 255], dtype=np.uint8).reshape((4, 1))
+        args, kwargs = mock_fromarray.call_args
+        np.testing.assert_array_equal(args[0].T, expected_image)
+        self.assertEqual(kwargs.get("mode"), "L")
+
+    @patch("rgc.utils.data.fits.getdata")
+    @patch("rgc.utils.data.fits.getheader")
+    def test_fits_to_png_file_not_found(self, mock_getheader, mock_getdata):
+        # Mock FileNotFoundError
+        mock_getdata.side_effect = FileNotFoundError
+
+        # Test FileNotFoundError
+        with self.assertRaises(_FileNotFoundError):
+            fits_to_png("mock.fits")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fits_to_png_bulk.py
+++ b/tests/test_fits_to_png_bulk.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from rgc.utils.data import fits_to_png_bulk
+
+
+class TestFitsToPngBulk(unittest.TestCase):
+    @patch("rgc.utils.data.fits_to_png")
+    @patch("rgc.utils.data.Path.rglob")
+    @patch("rgc.utils.data.Path.mkdir")
+    @patch("rgc.utils.data.os.path.join")
+    def test_fits_to_png_bulk(self, mock_join, mock_mkdir, mock_rglob, mock_fits_to_png):
+        # Mock rglob to return a list of fake FITS files
+        mock_fits_files = [Path(f"file{i}.fits") for i in range(3)]
+        mock_rglob.return_value = mock_fits_files
+
+        # Mock the PNG file path join
+        mock_join.side_effect = lambda png_dir, file_stem: f"{png_dir}/{file_stem}.png"
+
+        # Mock the image returned by fits_to_png
+        mock_image = MagicMock()
+        mock_fits_to_png.return_value = mock_image
+
+        # Call the function
+        fits_to_png_bulk("fits_dir", "png_dir", img_size=(100, 100))
+
+        # Assertions
+        mock_rglob.assert_called_once_with("*.fits")
+        mock_mkdir.assert_called()
+        self.assertEqual(mock_fits_to_png.call_count, 3)
+        self.assertEqual(mock_image.save.call_count, 3)
+
+        # Verify the image save calls
+        mock_image.save.assert_any_call("png_dir/file0.png")
+        mock_image.save.assert_any_call("png_dir/file1.png")
+        mock_image.save.assert_any_call("png_dir/file2.png")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1101,6 +1101,93 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "10.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06", size = 46555059 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/69/a31cccd538ca0b5272be2a38347f8839b97a14be104ea08b0db92f749c74/pillow-10.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e", size = 3509271 },
+    { url = "https://files.pythonhosted.org/packages/9a/9e/4143b907be8ea0bce215f2ae4f7480027473f8b61fcedfda9d851082a5d2/pillow-10.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:543f3dc61c18dafb755773efc89aae60d06b6596a63914107f75459cf984164d", size = 3375658 },
+    { url = "https://files.pythonhosted.org/packages/8a/25/1fc45761955f9359b1169aa75e241551e74ac01a09f487adaaf4c3472d11/pillow-10.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7928ecbf1ece13956b95d9cbcfc77137652b02763ba384d9ab508099a2eca856", size = 4332075 },
+    { url = "https://files.pythonhosted.org/packages/5e/dd/425b95d0151e1d6c951f45051112394f130df3da67363b6bc75dc4c27aba/pillow-10.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d49b85c4348ea0b31ea63bc75a9f3857869174e2bf17e7aba02945cd218e6f", size = 4444808 },
+    { url = "https://files.pythonhosted.org/packages/b1/84/9a15cc5726cbbfe7f9f90bfb11f5d028586595907cd093815ca6644932e3/pillow-10.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c762a5b0997f5659a5ef2266abc1d8851ad7749ad9a6a5506eb23d314e4f46b", size = 4356290 },
+    { url = "https://files.pythonhosted.org/packages/b5/5b/6651c288b08df3b8c1e2f8c1152201e0b25d240e22ddade0f1e242fc9fa0/pillow-10.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a985e028fc183bf12a77a8bbf36318db4238a3ded7fa9df1b9a133f1cb79f8fc", size = 4525163 },
+    { url = "https://files.pythonhosted.org/packages/07/8b/34854bf11a83c248505c8cb0fcf8d3d0b459a2246c8809b967963b6b12ae/pillow-10.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:812f7342b0eee081eaec84d91423d1b4650bb9828eb53d8511bcef8ce5aecf1e", size = 4463100 },
+    { url = "https://files.pythonhosted.org/packages/78/63/0632aee4e82476d9cbe5200c0cdf9ba41ee04ed77887432845264d81116d/pillow-10.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ac1452d2fbe4978c2eec89fb5a23b8387aba707ac72810d9490118817d9c0b46", size = 4592880 },
+    { url = "https://files.pythonhosted.org/packages/df/56/b8663d7520671b4398b9d97e1ed9f583d4afcbefbda3c6188325e8c297bd/pillow-10.4.0-cp310-cp310-win32.whl", hash = "sha256:bcd5e41a859bf2e84fdc42f4edb7d9aba0a13d29a2abadccafad99de3feff984", size = 2235218 },
+    { url = "https://files.pythonhosted.org/packages/f4/72/0203e94a91ddb4a9d5238434ae6c1ca10e610e8487036132ea9bf806ca2a/pillow-10.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:ecd85a8d3e79cd7158dec1c9e5808e821feea088e2f69a974db5edf84dc53141", size = 2554487 },
+    { url = "https://files.pythonhosted.org/packages/bd/52/7e7e93d7a6e4290543f17dc6f7d3af4bd0b3dd9926e2e8a35ac2282bc5f4/pillow-10.4.0-cp310-cp310-win_arm64.whl", hash = "sha256:ff337c552345e95702c5fde3158acb0625111017d0e5f24bf3acdb9cc16b90d1", size = 2243219 },
+    { url = "https://files.pythonhosted.org/packages/a7/62/c9449f9c3043c37f73e7487ec4ef0c03eb9c9afc91a92b977a67b3c0bbc5/pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c", size = 3509265 },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/491dafc7bbf5a3cc1845dc0430872e8096eb9e2b6f8161509d124594ec2d/pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be", size = 3375655 },
+    { url = "https://files.pythonhosted.org/packages/73/d5/c4011a76f4207a3c151134cd22a1415741e42fa5ddecec7c0182887deb3d/pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3", size = 4340304 },
+    { url = "https://files.pythonhosted.org/packages/ac/10/c67e20445a707f7a610699bba4fe050583b688d8cd2d202572b257f46600/pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6", size = 4452804 },
+    { url = "https://files.pythonhosted.org/packages/a9/83/6523837906d1da2b269dee787e31df3b0acb12e3d08f024965a3e7f64665/pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe", size = 4365126 },
+    { url = "https://files.pythonhosted.org/packages/ba/e5/8c68ff608a4203085158cff5cc2a3c534ec384536d9438c405ed6370d080/pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319", size = 4533541 },
+    { url = "https://files.pythonhosted.org/packages/f4/7c/01b8dbdca5bc6785573f4cee96e2358b0918b7b2c7b60d8b6f3abf87a070/pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d", size = 4471616 },
+    { url = "https://files.pythonhosted.org/packages/c8/57/2899b82394a35a0fbfd352e290945440e3b3785655a03365c0ca8279f351/pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696", size = 4600802 },
+    { url = "https://files.pythonhosted.org/packages/4d/d7/a44f193d4c26e58ee5d2d9db3d4854b2cfb5b5e08d360a5e03fe987c0086/pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496", size = 2235213 },
+    { url = "https://files.pythonhosted.org/packages/c1/d0/5866318eec2b801cdb8c82abf190c8343d8a1cd8bf5a0c17444a6f268291/pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91", size = 2554498 },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/310ac16ac2b97e902d9eb438688de0d961660a87703ad1561fd3dfbd2aa0/pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22", size = 2243219 },
+    { url = "https://files.pythonhosted.org/packages/05/cb/0353013dc30c02a8be34eb91d25e4e4cf594b59e5a55ea1128fde1e5f8ea/pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94", size = 3509350 },
+    { url = "https://files.pythonhosted.org/packages/e7/cf/5c558a0f247e0bf9cec92bff9b46ae6474dd736f6d906315e60e4075f737/pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597", size = 3374980 },
+    { url = "https://files.pythonhosted.org/packages/84/48/6e394b86369a4eb68b8a1382c78dc092245af517385c086c5094e3b34428/pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80", size = 4343799 },
+    { url = "https://files.pythonhosted.org/packages/3b/f3/a8c6c11fa84b59b9df0cd5694492da8c039a24cd159f0f6918690105c3be/pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca", size = 4459973 },
+    { url = "https://files.pythonhosted.org/packages/7d/1b/c14b4197b80150fb64453585247e6fb2e1d93761fa0fa9cf63b102fde822/pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef", size = 4370054 },
+    { url = "https://files.pythonhosted.org/packages/55/77/40daddf677897a923d5d33329acd52a2144d54a9644f2a5422c028c6bf2d/pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a", size = 4539484 },
+    { url = "https://files.pythonhosted.org/packages/40/54/90de3e4256b1207300fb2b1d7168dd912a2fb4b2401e439ba23c2b2cabde/pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b", size = 4477375 },
+    { url = "https://files.pythonhosted.org/packages/13/24/1bfba52f44193860918ff7c93d03d95e3f8748ca1de3ceaf11157a14cf16/pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9", size = 4608773 },
+    { url = "https://files.pythonhosted.org/packages/55/04/5e6de6e6120451ec0c24516c41dbaf80cce1b6451f96561235ef2429da2e/pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42", size = 2235690 },
+    { url = "https://files.pythonhosted.org/packages/74/0a/d4ce3c44bca8635bd29a2eab5aa181b654a734a29b263ca8efe013beea98/pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a", size = 2554951 },
+    { url = "https://files.pythonhosted.org/packages/b5/ca/184349ee40f2e92439be9b3502ae6cfc43ac4b50bc4fc6b3de7957563894/pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9", size = 2243427 },
+    { url = "https://files.pythonhosted.org/packages/c3/00/706cebe7c2c12a6318aabe5d354836f54adff7156fd9e1bd6c89f4ba0e98/pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3", size = 3525685 },
+    { url = "https://files.pythonhosted.org/packages/cf/76/f658cbfa49405e5ecbfb9ba42d07074ad9792031267e782d409fd8fe7c69/pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb", size = 3374883 },
+    { url = "https://files.pythonhosted.org/packages/46/2b/99c28c4379a85e65378211971c0b430d9c7234b1ec4d59b2668f6299e011/pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70", size = 4339837 },
+    { url = "https://files.pythonhosted.org/packages/f1/74/b1ec314f624c0c43711fdf0d8076f82d9d802afd58f1d62c2a86878e8615/pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be", size = 4455562 },
+    { url = "https://files.pythonhosted.org/packages/4a/2a/4b04157cb7b9c74372fa867096a1607e6fedad93a44deeff553ccd307868/pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0", size = 4366761 },
+    { url = "https://files.pythonhosted.org/packages/ac/7b/8f1d815c1a6a268fe90481232c98dd0e5fa8c75e341a75f060037bd5ceae/pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc", size = 4536767 },
+    { url = "https://files.pythonhosted.org/packages/e5/77/05fa64d1f45d12c22c314e7b97398ffb28ef2813a485465017b7978b3ce7/pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a", size = 4477989 },
+    { url = "https://files.pythonhosted.org/packages/12/63/b0397cfc2caae05c3fb2f4ed1b4fc4fc878f0243510a7a6034ca59726494/pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309", size = 4610255 },
+    { url = "https://files.pythonhosted.org/packages/7b/f9/cfaa5082ca9bc4a6de66ffe1c12c2d90bf09c309a5f52b27759a596900e7/pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060", size = 2235603 },
+    { url = "https://files.pythonhosted.org/packages/01/6a/30ff0eef6e0c0e71e55ded56a38d4859bf9d3634a94a88743897b5f96936/pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea", size = 2554972 },
+    { url = "https://files.pythonhosted.org/packages/48/2c/2e0a52890f269435eee38b21c8218e102c621fe8d8df8b9dd06fabf879ba/pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d", size = 2243375 },
+    { url = "https://files.pythonhosted.org/packages/56/70/f40009702a477ce87d8d9faaa4de51d6562b3445d7a314accd06e4ffb01d/pillow-10.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:8d4d5063501b6dd4024b8ac2f04962d661222d120381272deea52e3fc52d3736", size = 3509213 },
+    { url = "https://files.pythonhosted.org/packages/10/43/105823d233c5e5d31cea13428f4474ded9d961652307800979a59d6a4276/pillow-10.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7c1ee6f42250df403c5f103cbd2768a28fe1a0ea1f0f03fe151c8741e1469c8b", size = 3375883 },
+    { url = "https://files.pythonhosted.org/packages/3c/ad/7850c10bac468a20c918f6a5dbba9ecd106ea1cdc5db3c35e33a60570408/pillow-10.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b15e02e9bb4c21e39876698abf233c8c579127986f8207200bc8a8f6bb27acf2", size = 4330810 },
+    { url = "https://files.pythonhosted.org/packages/84/4c/69bbed9e436ac22f9ed193a2b64f64d68fcfbc9f4106249dc7ed4889907b/pillow-10.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a8d4bade9952ea9a77d0c3e49cbd8b2890a399422258a77f357b9cc9be8d680", size = 4444341 },
+    { url = "https://files.pythonhosted.org/packages/8f/4f/c183c63828a3f37bf09644ce94cbf72d4929b033b109160a5379c2885932/pillow-10.4.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:43efea75eb06b95d1631cb784aa40156177bf9dd5b4b03ff38979e048258bc6b", size = 4356005 },
+    { url = "https://files.pythonhosted.org/packages/fb/ad/435fe29865f98a8fbdc64add8875a6e4f8c97749a93577a8919ec6f32c64/pillow-10.4.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:950be4d8ba92aca4b2bb0741285a46bfae3ca699ef913ec8416c1b78eadd64cd", size = 4525201 },
+    { url = "https://files.pythonhosted.org/packages/80/74/be8bf8acdfd70e91f905a12ae13cfb2e17c0f1da745c40141e26d0971ff5/pillow-10.4.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d7480af14364494365e89d6fddc510a13e5a2c3584cb19ef65415ca57252fb84", size = 4460635 },
+    { url = "https://files.pythonhosted.org/packages/e4/90/763616e66dc9ad59c9b7fb58f863755e7934ef122e52349f62c7742b82d3/pillow-10.4.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:73664fe514b34c8f02452ffb73b7a92c6774e39a647087f83d67f010eb9a0cf0", size = 4590283 },
+    { url = "https://files.pythonhosted.org/packages/69/66/03002cb5b2c27bb519cba63b9f9aa3709c6f7a5d3b285406c01f03fb77e5/pillow-10.4.0-cp38-cp38-win32.whl", hash = "sha256:e88d5e6ad0d026fba7bdab8c3f225a69f063f116462c49892b0149e21b6c0a0e", size = 2235185 },
+    { url = "https://files.pythonhosted.org/packages/f2/75/3cb820b2812405fc7feb3d0deb701ef0c3de93dc02597115e00704591bc9/pillow-10.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:5161eef006d335e46895297f642341111945e2c1c899eb406882a6c61a4357ab", size = 2554594 },
+    { url = "https://files.pythonhosted.org/packages/31/85/955fa5400fa8039921f630372cfe5056eed6e1b8e0430ee4507d7de48832/pillow-10.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0ae24a547e8b711ccaaf99c9ae3cd975470e1a30caa80a6aaee9a2f19c05701d", size = 3509283 },
+    { url = "https://files.pythonhosted.org/packages/23/9c/343827267eb28d41cd82b4180d33b10d868af9077abcec0af9793aa77d2d/pillow-10.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:298478fe4f77a4408895605f3482b6cc6222c018b2ce565c2b6b9c354ac3229b", size = 3375691 },
+    { url = "https://files.pythonhosted.org/packages/60/a3/7ebbeabcd341eab722896d1a5b59a3df98c4b4d26cf4b0385f8aa94296f7/pillow-10.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:134ace6dc392116566980ee7436477d844520a26a4b1bd4053f6f47d096997fd", size = 4328295 },
+    { url = "https://files.pythonhosted.org/packages/32/3f/c02268d0c6fb6b3958bdda673c17b315c821d97df29ae6969f20fb49388a/pillow-10.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:930044bb7679ab003b14023138b50181899da3f25de50e9dbee23b61b4de2126", size = 4440810 },
+    { url = "https://files.pythonhosted.org/packages/67/5d/1c93c8cc35f2fdd3d6cc7e4ad72d203902859a2867de6ad957d9b708eb8d/pillow-10.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c76e5786951e72ed3686e122d14c5d7012f16c8303a674d18cdcd6d89557fc5b", size = 4352283 },
+    { url = "https://files.pythonhosted.org/packages/bc/a8/8655557c9c7202b8abbd001f61ff36711cefaf750debcaa1c24d154ef602/pillow-10.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b2724fdb354a868ddf9a880cb84d102da914e99119211ef7ecbdc613b8c96b3c", size = 4521800 },
+    { url = "https://files.pythonhosted.org/packages/58/78/6f95797af64d137124f68af1bdaa13b5332da282b86031f6fa70cf368261/pillow-10.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dbc6ae66518ab3c5847659e9988c3b60dc94ffb48ef9168656e0019a93dbf8a1", size = 4459177 },
+    { url = "https://files.pythonhosted.org/packages/8a/6d/2b3ce34f1c4266d79a78c9a51d1289a33c3c02833fe294ef0dcbb9cba4ed/pillow-10.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:06b2f7898047ae93fad74467ec3d28fe84f7831370e3c258afa533f81ef7f3df", size = 4589079 },
+    { url = "https://files.pythonhosted.org/packages/e3/e0/456258c74da1ff5bf8ef1eab06a95ca994d8b9ed44c01d45c3f8cbd1db7e/pillow-10.4.0-cp39-cp39-win32.whl", hash = "sha256:7970285ab628a3779aecc35823296a7869f889b8329c16ad5a71e4901a3dc4ef", size = 2235247 },
+    { url = "https://files.pythonhosted.org/packages/37/f8/bef952bdb32aa53741f58bf21798642209e994edc3f6598f337f23d5400a/pillow-10.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:961a7293b2457b405967af9c77dcaa43cc1a8cd50d23c532e62d48ab6cdd56f5", size = 2554479 },
+    { url = "https://files.pythonhosted.org/packages/bb/8e/805201619cad6651eef5fc1fdef913804baf00053461522fabbc5588ea12/pillow-10.4.0-cp39-cp39-win_arm64.whl", hash = "sha256:32cda9e3d601a52baccb2856b8ea1fc213c90b340c542dcef77140dfa3278a9e", size = 2243226 },
+    { url = "https://files.pythonhosted.org/packages/38/30/095d4f55f3a053392f75e2eae45eba3228452783bab3d9a920b951ac495c/pillow-10.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5b4815f2e65b30f5fbae9dfffa8636d992d49705723fe86a3661806e069352d4", size = 3493889 },
+    { url = "https://files.pythonhosted.org/packages/f3/e8/4ff79788803a5fcd5dc35efdc9386af153569853767bff74540725b45863/pillow-10.4.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8f0aef4ef59694b12cadee839e2ba6afeab89c0f39a3adc02ed51d109117b8da", size = 3346160 },
+    { url = "https://files.pythonhosted.org/packages/d7/ac/4184edd511b14f760c73f5bb8a5d6fd85c591c8aff7c2229677a355c4179/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f4727572e2918acaa9077c919cbbeb73bd2b3ebcfe033b72f858fc9fbef0026", size = 3435020 },
+    { url = "https://files.pythonhosted.org/packages/da/21/1749cd09160149c0a246a81d646e05f35041619ce76f6493d6a96e8d1103/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff25afb18123cea58a591ea0244b92eb1e61a1fd497bf6d6384f09bc3262ec3e", size = 3490539 },
+    { url = "https://files.pythonhosted.org/packages/b6/f5/f71fe1888b96083b3f6dfa0709101f61fc9e972c0c8d04e9d93ccef2a045/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dc3e2db6ba09ffd7d02ae9141cfa0ae23393ee7687248d46a7507b75d610f4f5", size = 3476125 },
+    { url = "https://files.pythonhosted.org/packages/96/b9/c0362c54290a31866c3526848583a2f45a535aa9d725fd31e25d318c805f/pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885", size = 3579373 },
+    { url = "https://files.pythonhosted.org/packages/52/3b/ce7a01026a7cf46e5452afa86f97a5e88ca97f562cafa76570178ab56d8d/pillow-10.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0755ffd4a0c6f267cccbae2e9903d95477ca2f77c4fcf3a3a09570001856c8a5", size = 2554661 },
+    { url = "https://files.pythonhosted.org/packages/e1/1f/5a9fcd6ced51633c22481417e11b1b47d723f64fb536dfd67c015eb7f0ab/pillow-10.4.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a02364621fe369e06200d4a16558e056fe2805d3468350df3aef21e00d26214b", size = 3493850 },
+    { url = "https://files.pythonhosted.org/packages/cb/e6/3ea4755ed5320cb62aa6be2f6de47b058c6550f752dd050e86f694c59798/pillow-10.4.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1b5dea9831a90e9d0721ec417a80d4cbd7022093ac38a568db2dd78363b00908", size = 3346118 },
+    { url = "https://files.pythonhosted.org/packages/0a/22/492f9f61e4648422b6ca39268ec8139277a5b34648d28f400faac14e0f48/pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b885f89040bb8c4a1573566bbb2f44f5c505ef6e74cec7ab9068c900047f04b", size = 3434958 },
+    { url = "https://files.pythonhosted.org/packages/f9/19/559a48ad4045704bb0547965b9a9345f5cd461347d977a56d178db28819e/pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87dd88ded2e6d74d31e1e0a99a726a6765cda32d00ba72dc37f0651f306daaa8", size = 3490340 },
+    { url = "https://files.pythonhosted.org/packages/d9/de/cebaca6fb79905b3a1aa0281d238769df3fb2ede34fd7c0caa286575915a/pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:2db98790afc70118bd0255c2eeb465e9767ecf1f3c25f9a1abb8ffc8cfd1fe0a", size = 3476048 },
+    { url = "https://files.pythonhosted.org/packages/71/f0/86d5b2f04693b0116a01d75302b0a307800a90d6c351a8aa4f8ae76cd499/pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f7baece4ce06bade126fb84b8af1c33439a76d8a6fd818970215e0560ca28c27", size = 3579366 },
+    { url = "https://files.pythonhosted.org/packages/37/ae/2dbfc38cc4fd14aceea14bc440d5151b21f64c4c3ba3f6f4191610b7ee5d/pillow-10.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cfdd747216947628af7b259d274771d84db2268ca062dd5faf373639d00113a3", size = 2554652 },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1657,11 +1744,14 @@ wheels = [
 
 [[package]]
 name = "rgc"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "astropy" },
     { name = "astroquery" },
+    { name = "numpy" },
     { name = "pandas" },
+    { name = "pillow" },
 ]
 
 [package.dev-dependencies]
@@ -1683,8 +1773,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "astropy", specifier = ">=5.2.2" },
     { name = "astroquery", specifier = ">=0.4.7" },
+    { name = "numpy", specifier = ">=1.24.4" },
     { name = "pandas", specifier = ">=2.0.3" },
+    { name = "pillow", specifier = ">=10.4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- Implemented `fits_to_png` function to convert a single FITS image to PNG.
- Implemented `fits_to_png_bulk` function to convert all FITS images in a directory to PNG.
- Handled normalization of pixel values between 0 and 255.
- Added `_FileNotFoundError` for handling missing FITS files.
- Included unittests for both `fits_to_png` and `fits_to_png_bulk`.
- Mocked external dependencies such as file reading and saving in tests.

Closes #5